### PR TITLE
Setup app for PaaS

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: pipenv run ./manage.py runserver 0.0.0.0:$PORT
+web: ./manage.py runserver 0.0.0.0:$PORT

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -48,6 +48,22 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'conf.urls'
 
+# CloudFoundry PaaS env vars
+CF_VCAP_SERVICES = env.json("VCAP_SERVICES")
+CF_VCAP_APPLICATION = env.json("VCAP_APPLICATION")
+
+# Populate DATABASE_URL and SPIRE_DATABASE_URL env vars from PaaS
+# service info based service binding name
+try:
+    paas_db_uris = {
+        d["name"]: d["credentials"]["uri"] for d in CF_VCAP_SERVICES["postgres"]
+    }
+
+    os.environ["DATABASE_URL"] = paas_db_uris["default"]
+    os.environ["SPIRE_DATABASE_URL"] = paas_db_uris["spire"]
+except KeyError:
+    pass
+
 # Database
 DATABASES = {
     'default': env.db(),

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -49,8 +49,8 @@ MIDDLEWARE = [
 ROOT_URLCONF = 'conf.urls'
 
 # CloudFoundry PaaS env vars
-CF_VCAP_SERVICES = env.json("VCAP_SERVICES")
-CF_VCAP_APPLICATION = env.json("VCAP_APPLICATION")
+CF_VCAP_SERVICES = env.json("VCAP_SERVICES", {})
+CF_VCAP_APPLICATION = env.json("VCAP_APPLICATION", {})
 
 # Populate DATABASE_URL and SPIRE_DATABASE_URL env vars from PaaS
 # service info based service binding name

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7
+python-3.7.7


### PR DESCRIPTION
- specifies a supported python runtime
- fixes Procfile for PaaS
- handles creating Django `DATABASES` config from PaaS `VCAP_SERVICES` env var
